### PR TITLE
Add DLSS input preprocessing toggle and hooks

### DIFF
--- a/ReShade.vcxproj
+++ b/ReShade.vcxproj
@@ -639,11 +639,13 @@
     <ClCompile Include="source\openxr\openxr_impl_swapchain.cpp" />
     <ClCompile Include="source\platform_utils.cpp" />
     <ClCompile Include="source\runtime.cpp" />
+    <ClCompile Include="source\runtime_dlss_preprocess.cpp" />
     <ClCompile Include="source\runtime_api.cpp" />
     <ClCompile Include="source\runtime_gui.cpp" />
     <ClCompile Include="source\runtime_gui_vr.cpp" />
     <ClCompile Include="source\runtime_manager.cpp" />
     <ClCompile Include="source\runtime_update_check.cpp" />
+    <ClCompile Include="source\nvngx\nvngx_hooks.cpp" />
     <ClCompile Include="source\state_block.cpp" />
     <ClCompile Include="source\vulkan\vulkan_hooks.cpp" />
     <ClCompile Include="source\vulkan\vulkan_hooks_cmd.cpp" />
@@ -758,6 +760,7 @@
     <ClInclude Include="source\platform_utils.hpp" />
     <ClInclude Include="source\reshade_api_object_impl.hpp" />
     <ClInclude Include="source\runtime.hpp" />
+    <ClInclude Include="source\runtime_dlss_preprocess.hpp" />
     <ClInclude Include="source\runtime_internal.hpp" />
     <ClInclude Include="source\runtime_manager.hpp" />
     <ClInclude Include="source\state_block.hpp" />

--- a/ReShade.vcxproj.filters
+++ b/ReShade.vcxproj.filters
@@ -67,6 +67,9 @@
     <Filter Include="hooks\openxr">
       <UniqueIdentifier>{6e1dc50f-a845-48b7-bc1c-852c22956b19}</UniqueIdentifier>
     </Filter>
+    <Filter Include="hooks\nvngx">
+      <UniqueIdentifier>{b6a8c5f4-4f34-4dbf-8a3f-9bf6a8299bb4}</UniqueIdentifier>
+    </Filter>
     <Filter Include="hooks\vulkan">
       <UniqueIdentifier>{40ae025e-f912-4ebf-9a43-69d7c1a96d3e}</UniqueIdentifier>
     </Filter>
@@ -375,6 +378,9 @@
     <ClCompile Include="source\openxr\openxr_hooks_swapchain.cpp">
       <Filter>hooks\openxr</Filter>
     </ClCompile>
+    <ClCompile Include="source\nvngx\nvngx_hooks.cpp">
+      <Filter>hooks\nvngx</Filter>
+    </ClCompile>
     <ClCompile Include="source\openxr\openxr_impl_swapchain.cpp">
       <Filter>hooks\openxr</Filter>
     </ClCompile>
@@ -382,6 +388,9 @@
       <Filter>core\utils</Filter>
     </ClCompile>
     <ClCompile Include="source\runtime.cpp">
+      <Filter>core\runtime</Filter>
+    </ClCompile>
+    <ClCompile Include="source\runtime_dlss_preprocess.cpp">
       <Filter>core\runtime</Filter>
     </ClCompile>
     <ClCompile Include="source\runtime_api.cpp">
@@ -729,6 +738,9 @@
       <Filter>api</Filter>
     </ClInclude>
     <ClInclude Include="source\runtime.hpp">
+      <Filter>core\runtime</Filter>
+    </ClInclude>
+    <ClInclude Include="source\runtime_dlss_preprocess.hpp">
       <Filter>core\runtime</Filter>
     </ClInclude>
     <ClInclude Include="source\runtime_internal.hpp">

--- a/res/exports.def
+++ b/res/exports.def
@@ -52,6 +52,9 @@ EXPORTS
 	D3D12SerializeRootSignature PRIVATE
 	D3D12SerializeVersionedRootSignature PRIVATE
 
+	; nvngx_dlss.dll
+	NVSDK_NGX_D3D12_EvaluateFeature PRIVATE
+
 	; ddraw.dll
 	DirectDrawCreate @8 PRIVATE
 	DirectDrawCreateEx @10 PRIVATE

--- a/source/dll_main.cpp
+++ b/source/dll_main.cpp
@@ -331,16 +331,18 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD fdwReason, LPVOID)
 					}
 
 					// Only register OpenGL hooks when module is not called any D3D module name
-					if ((!is_d3d && !is_dxgi) || config.get("INSTALL", "HookOpenGL"))
-					{
-						reshade::hooks::register_module(get_system_path() / L"opengl32.dll");
+						if ((!is_d3d && !is_dxgi) || config.get("INSTALL", "HookOpenGL"))
+						{
+							reshade::hooks::register_module(get_system_path() / L"opengl32.dll");
+						}
+
+						// Do not register Vulkan hooks, since Vulkan layering mechanism is used instead
+
+						reshade::hooks::register_module(L"openvr_api.dll");
+						reshade::hooks::register_module(L"nvngx_dlss.dll");
+						reshade::hooks::register_module(L"_nvngx_dlss.dll");
+						}
 					}
-
-					// Do not register Vulkan hooks, since Vulkan layering mechanism is used instead
-
-					reshade::hooks::register_module(L"openvr_api.dll");
-				}
-			}
 
 			reshade::log::message(reshade::log::level::info, "Initialized.");
 			break;

--- a/source/nvngx/nvngx_hooks.cpp
+++ b/source/nvngx/nvngx_hooks.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2025 Patrick Mours
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "d3d12/d3d12_device.hpp"
+#include "d3d12/d3d12_command_list.hpp"
+#include "d3d12/d3d12_impl_type_convert.hpp"
+#include "runtime_dlss_preprocess.hpp"
+#include "hook_manager.hpp"
+
+#include <mutex>
+
+struct NVSDK_NGX_Handle;
+
+#ifndef NVSDK_CONV
+#define NVSDK_CONV __cdecl
+#endif
+
+enum NVSDK_NGX_Result
+{
+	NVSDK_NGX_Result_Success = 0x1
+};
+
+struct NVSDK_NGX_Parameter
+{
+	virtual void Set(const char *, unsigned long long) = 0;
+	virtual void Set(const char *, float) = 0;
+	virtual void Set(const char *, double) = 0;
+	virtual void Set(const char *, unsigned int) = 0;
+	virtual void Set(const char *, int) = 0;
+	virtual void Set(const char *, ID3D11Resource *) = 0;
+	virtual void Set(const char *, ID3D12Resource *) = 0;
+	virtual void Set(const char *, void *) = 0;
+
+	virtual NVSDK_NGX_Result Get(const char *, unsigned long long *) const = 0;
+	virtual NVSDK_NGX_Result Get(const char *, float *) const = 0;
+	virtual NVSDK_NGX_Result Get(const char *, double *) const = 0;
+	virtual NVSDK_NGX_Result Get(const char *, unsigned int *) const = 0;
+	virtual NVSDK_NGX_Result Get(const char *, int *) const = 0;
+	virtual NVSDK_NGX_Result Get(const char *, ID3D11Resource **) const = 0;
+	virtual NVSDK_NGX_Result Get(const char *, ID3D12Resource **) const = 0;
+	virtual NVSDK_NGX_Result Get(const char *, void **) const = 0;
+
+	virtual void Reset() = 0;
+};
+
+typedef void (NVSDK_CONV *PFN_NVSDK_NGX_ProgressCallback)(float, bool &);
+
+extern "C" NVSDK_NGX_Result NVSDK_CONV NVSDK_NGX_D3D12_EvaluateFeature(
+	ID3D12GraphicsCommandList *InCmdList,
+	const NVSDK_NGX_Handle *InFeatureHandle,
+	NVSDK_NGX_Parameter *InParameters,
+	PFN_NVSDK_NGX_ProgressCallback InCallback)
+{
+	static const auto trampoline = reshade::hooks::call(NVSDK_NGX_D3D12_EvaluateFeature);
+
+	if (InCmdList == nullptr || InParameters == nullptr)
+		return trampoline(InCmdList, InFeatureHandle, InParameters, InCallback);
+
+	auto command_list_proxy = static_cast<D3D12GraphicsCommandList *>(InCmdList);
+	auto cmd_list_impl = static_cast<reshade::d3d12::command_list_impl *>(command_list_proxy);
+	auto device_impl = static_cast<reshade::d3d12::device_impl *>(cmd_list_impl->get_device());
+
+	reshade::runtime *runtime_instance = nullptr;
+	if (auto data = reshade::get_preprocess_runtime_data(device_impl))
+	{
+		std::unique_lock<std::mutex> lock(data->mutex);
+		for (reshade::runtime *candidate : data->runtimes)
+		{
+			if (candidate != nullptr && candidate->get_device() == device_impl)
+			{
+				runtime_instance = candidate;
+				break;
+			}
+		}
+	}
+
+	if (runtime_instance != nullptr && runtime_instance->is_preprocess_dlss_input_enabled())
+	{
+		ID3D12Resource *color_native = nullptr;
+		if (InParameters->Get("Color", &color_native) == NVSDK_NGX_Result_Success && color_native != nullptr)
+		{
+			const reshade::api::resource color_resource = reshade::d3d12::to_handle(color_native);
+			const reshade::api::resource_desc color_desc = device_impl->get_resource_desc(color_resource);
+
+			reshade::api::format render_format = color_desc.texture.format;
+			if (render_format != reshade::api::format::unknown &&
+				reshade::api::format_to_typeless(render_format) == render_format)
+			{
+				const reshade::api::format typed_format = reshade::api::format_to_default_typed(render_format, 0);
+				if (typed_format == reshade::api::format::unknown)
+					render_format = reshade::api::format::unknown;
+				else
+					render_format = typed_format;
+			}
+
+			if (render_format != reshade::api::format::unknown)
+			{
+				reshade::api::resource_view rtv = {};
+				reshade::api::resource_view rtv_srgb = {};
+
+				const reshade::api::resource_view_desc view_desc(render_format);
+				if (device_impl->create_resource_view(color_resource, reshade::api::resource_usage::render_target, view_desc, &rtv))
+				{
+					reshade::api::format srgb_format = reshade::api::format_to_default_typed(render_format, 1);
+					if (srgb_format == reshade::api::format::unknown)
+						srgb_format = render_format;
+
+					if (srgb_format != render_format)
+					{
+						const reshade::api::resource_view_desc srgb_desc(srgb_format);
+						if (!device_impl->create_resource_view(color_resource, reshade::api::resource_usage::render_target, srgb_desc, &rtv_srgb))
+							srgb_format = render_format;
+					}
+
+					if (rtv_srgb.handle == 0)
+						rtv_srgb = rtv;
+
+					const reshade::api::resource resources[] = { color_resource };
+					const reshade::api::resource_usage state_before[] = { reshade::api::resource_usage::shader_resource };
+					const reshade::api::resource_usage state_target[] = { reshade::api::resource_usage::render_target };
+
+					cmd_list_impl->barrier(1, resources, state_before, state_target);
+					runtime_instance->render_effects(cmd_list_impl, rtv, rtv_srgb);
+					cmd_list_impl->barrier(1, resources, state_target, state_before);
+
+					if (rtv_srgb != rtv)
+						device_impl->destroy_resource_view(rtv_srgb);
+					device_impl->destroy_resource_view(rtv);
+				}
+			}
+		}
+	}
+
+	return trampoline(InCmdList, InFeatureHandle, InParameters, InCallback);
+}

--- a/source/runtime.cpp
+++ b/source/runtime.cpp
@@ -913,6 +913,7 @@ void reshade::runtime::load_config()
 	config_get("GENERAL", "PerformanceMode", _performance_mode);
 	config_get("GENERAL", "PreprocessorDefinitions", _global_preprocessor_definitions);
 	config_get("GENERAL", "SkipLoadingDisabledEffects", _effect_load_skipping);
+	config_get("GENERAL", "PreprocessDLSSInput", _preprocess_dlss_input);
 	config_get("GENERAL", "TextureSearchPaths", _texture_search_paths);
 	config_get("GENERAL", "IntermediateCachePath", _effect_cache_path);
 
@@ -992,6 +993,7 @@ void reshade::runtime::save_config() const
 	config.set("GENERAL", "PerformanceMode", _performance_mode);
 	config.set("GENERAL", "PreprocessorDefinitions", _global_preprocessor_definitions);
 	config.set("GENERAL", "SkipLoadingDisabledEffects", _effect_load_skipping);
+	config.set("GENERAL", "PreprocessDLSSInput", _preprocess_dlss_input);
 	config.set("GENERAL", "TextureSearchPaths", _texture_search_paths);
 	config.set("GENERAL", "IntermediateCachePath", _effect_cache_path);
 

--- a/source/runtime.hpp
+++ b/source/runtime.hpp
@@ -62,6 +62,8 @@ namespace reshade
 		void render_effects(api::command_list *cmd_list, api::resource_view rtv, api::resource_view rtv_srgb) final;
 		void render_technique(api::effect_technique handle, api::command_list *cmd_list, api::resource_view rtv, api::resource_view rtv_srgb) final;
 
+		bool is_preprocess_dlss_input_enabled() const { return _preprocess_dlss_input; }
+
 		/// <summary>
 		/// Captures a screenshot of the current back buffer resource and writes it to an image file on disk.
 		/// </summary>
@@ -267,6 +269,7 @@ namespace reshade
 
 		bool _effects_enabled = true;
 		bool _effects_rendered_this_frame = false;
+		bool _preprocess_dlss_input = false;
 		unsigned int _effects_key_data[4] = {};
 
 		std::chrono::system_clock::time_point _current_time;

--- a/source/runtime_dlss_preprocess.cpp
+++ b/source/runtime_dlss_preprocess.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2025 Patrick Mours
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "runtime_dlss_preprocess.hpp"
+#include "reshade_api_device.hpp"
+#include <algorithm>
+
+namespace reshade
+{
+	preprocess_runtime_device_data *get_preprocess_runtime_data(api::device *device)
+	{
+		if (device == nullptr)
+			return nullptr;
+
+		return device->get_private_data<preprocess_runtime_device_data>();
+	}
+
+	static preprocess_runtime_device_data *ensure_preprocess_runtime_data(api::device *device)
+	{
+		auto data = get_preprocess_runtime_data(device);
+		if (data == nullptr)
+			data = device->create_private_data<preprocess_runtime_device_data>();
+		return data;
+	}
+
+	void register_preprocess_runtime(api::device *device, runtime *runtime_instance)
+	{
+		if (device == nullptr || runtime_instance == nullptr)
+			return;
+
+		auto data = ensure_preprocess_runtime_data(device);
+		std::lock_guard<std::mutex> lock(data->mutex);
+		if (std::find(data->runtimes.begin(), data->runtimes.end(), runtime_instance) == data->runtimes.end())
+			data->runtimes.push_back(runtime_instance);
+	}
+
+	void unregister_preprocess_runtime(api::device *device, runtime *runtime_instance)
+	{
+		if (device == nullptr)
+			return;
+
+		if (auto data = get_preprocess_runtime_data(device))
+		{
+			std::unique_lock<std::mutex> lock(data->mutex);
+			if (runtime_instance != nullptr)
+				data->runtimes.erase(std::remove(data->runtimes.begin(), data->runtimes.end(), runtime_instance), data->runtimes.end());
+
+			const bool empty = data->runtimes.empty();
+			lock.unlock();
+
+			if (empty)
+				device->destroy_private_data<preprocess_runtime_device_data>();
+		}
+	}
+}

--- a/source/runtime_dlss_preprocess.hpp
+++ b/source/runtime_dlss_preprocess.hpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2025 Patrick Mours
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#pragma once
+
+#include "runtime.hpp"
+#include <mutex>
+#include <vector>
+
+namespace reshade
+{
+	struct __declspec(uuid("8A9549DA-6243-49E5-9A04-2F4C0D1F9C62")) preprocess_runtime_device_data
+	{
+		std::mutex mutex;
+		std::vector<runtime *> runtimes;
+	};
+
+	preprocess_runtime_device_data *get_preprocess_runtime_data(api::device *device);
+	void register_preprocess_runtime(api::device *device, runtime *runtime_instance);
+	void unregister_preprocess_runtime(api::device *device, runtime *runtime_instance);
+}

--- a/source/runtime_gui.cpp
+++ b/source/runtime_gui.cpp
@@ -2078,6 +2078,9 @@ void reshade::runtime::draw_gui_settings()
 			reload_effects(!_effect_load_skipping);
 		}
 
+		modified |= ImGui::Checkbox(_("Preprocess DLSS Input Image"), &_preprocess_dlss_input);
+		ImGui::SetItemTooltip(_("Apply ReShade techniques to the low resolution image provided to DLSS before upscaling."));
+
 		if (ImGui::Button(_("Clear effect cache"), ImVec2(ImGui::CalcItemWidth(), 0)))
 			clear_effect_cache();
 		ImGui::SetItemTooltip(_("Clear effect cache located in \"%s\"."), _effect_cache_path.u8string().c_str());

--- a/source/runtime_manager.cpp
+++ b/source/runtime_manager.cpp
@@ -5,6 +5,7 @@
 
 #include "runtime.hpp"
 #include "runtime_manager.hpp"
+#include "runtime_dlss_preprocess.hpp"
 #include "ini_file.hpp"
 #include <cassert>
 #include <shared_mutex>
@@ -46,6 +47,9 @@ void reshade::create_effect_runtime(api::swapchain *swapchain, api::command_queu
 		return;
 
 	swapchain->create_private_data<reshade::runtime>(swapchain, graphics_queue, config.path(), vr);
+
+	if (auto runtime = swapchain->get_private_data<reshade::runtime>())
+		register_preprocess_runtime(swapchain->get_device(), runtime);
 }
 void reshade::destroy_effect_runtime(api::swapchain *swapchain)
 {
@@ -57,6 +61,8 @@ void reshade::destroy_effect_runtime(api::swapchain *swapchain)
 		const std::unique_lock<std::shared_mutex> lock(s_runtime_config_names_mutex);
 
 		s_runtime_config_names.erase(config_name);
+
+		unregister_preprocess_runtime(swapchain->get_device(), runtime);
 	}
 
 	swapchain->destroy_private_data<reshade::runtime>();


### PR DESCRIPTION
## Summary
- add a device-level registry that lets DLSS hooks locate active runtimes
- hook NVSDK DLSS evaluation so effects can render on the low-resolution input when enabled
- expose a "Preprocess DLSS Input Image" toggle in configuration, GUI, and module initialization

## Testing
- not run (Windows-only project)

------
https://chatgpt.com/codex/tasks/task_e_68cfc2d4a2c88322b5ae269ef3d024d9